### PR TITLE
Fix "how it works" navigation link

### DIFF
--- a/script.js
+++ b/script.js
@@ -234,7 +234,7 @@ document.addEventListener('DOMContentLoaded', function() {
     // Add section ID attributes for smooth scrolling
     const sectionElements = {
         'Why Direct-Mail Still Wins': 'why-direct-mail',
-        'How It Works': 'how-it-works',
+        'How It Works': 'how-works',
         'Real-Time Availability': 'availability',
         'Sizes & Investment': 'pricing',
         'Mailing Map & Drop Dates': 'mailing-map',


### PR DESCRIPTION
Correct JavaScript mapping for the "How It Works" section ID to fix the broken navigation link.

The JavaScript was dynamically assigning an ID of `'how-it-works'` (with an extra dash) to the "How It Works" section, overriding the correct existing HTML ID of `'how-works'`. This mismatch prevented the navigation link from scrolling to the intended section.

---
<a href="https://cursor.com/background-agent?bcId=bc-0e32eb51-b4b4-4a25-a536-7038f78c3f73">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-0e32eb51-b4b4-4a25-a536-7038f78c3f73">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>