### PR TITLE
Update homepage copy, pricing, imagery and add partner-ads marquee

### DIFF
--- a/index.html
+++ b/index.html
@@ -1282,12 +1282,12 @@
                 <h2 class="hero-sub-headline fade-in-delay-2" style="font-size: 1.2rem; font-weight: 600; margin: 20px 0; text-align: center; line-height: 1.6; white-space: normal;">
                     <span style="color: #d4af37;">We print it.</span> 
                     <span style="color: #4FC3F7;">We mail it.</span> 
-                    <span style="color: #FF0000; display: inline-block;">You get seen.</span> 
+                    <span style="color: #d4af37; display: inline-block;">You get seen.</span> 
                     <span style="color: #FFFFFF; text-shadow: 1px 1px 3px rgba(0,0,0,0.5);">It's that simple</span>
                 </h2>
                 <p class="hero-paragraph fade-in-delay-2">Get Featured with other businesses on a giant postcard, 
 
-It's proven, affordable, exclusive, and designed for maximum exposure. Lock in this promo price for all future mailings as a launch member</p>
+It's proven, affordable, exclusive category, and designed for maximum exposure. Lock in this promo price now for all future mailings as a launch member</p>
                 <div class="btn-group fade-in-delay-3" style="gap: 16px; align-items: flex-start;">
                     <div style="display: flex; flex-direction: column; align-items: center; flex-shrink: 0;">
                         <a href="#" class="btn btn-primary lock-shaped-btn shimmer-button" id="secure-spot-btn">
@@ -1366,7 +1366,7 @@ Es comprobado, asequible, exclusivo, y diseñado para máxima exposición. Asegu
             
             <div class="hero-images">
                 <div class="image-container">
-                    <img src="c8j30gm2y3.png" alt="Lennox Local Summer 2025 Postcard" class="hero-main-image fade-in-delay-2">
+                    <img src="ywaayafkyy.png" alt="Updated Support Local Businesses postcard" class="hero-main-image fade-in-delay-2">
                 </div>
                 <div class="image-container">
                     <img src="LOCAL ADS FLYER Large Post Card.png" alt="Local Ads Flyer large postcard" class="hero-second-image fade-in-delay-3">
@@ -1388,8 +1388,8 @@ Es comprobado, asequible, exclusivo, y diseñado para máxima exposición. Asegu
                 <h3 class="updates-heading en">New Starter Postcards Available!</h3>
                 <h3 class="updates-heading es" style="display: none;">Nuevas Postales Starter Disponibles!</h3>
                 <div class="updates-body" id="updates-body">
-                    <p class="updates-text en">A great way to get started for just one low price of $150.</p>
-                    <p class="updates-text es" style="display: none;">Una gran manera de empezar por un solo precio bajo de $150.</p>
+                    <p class="updates-text en">A great way to get started for just one low promotional price of $158.</p>
+                    <p class="updates-text es" style="display: none;">Una gran manera de empezar por un solo precio promocional bajo de $158.</p>
                 </div>
                 <button type="button" class="updates-read-more en" data-more="Read More" data-less="Read Less" aria-expanded="false" aria-controls="updates-body">
                     <span class="updates-read-more-label">Read More</span>
@@ -1402,6 +1402,128 @@ Es comprobado, asequible, exclusivo, y diseñado para máxima exposición. Asegu
             </div>
         </div>
     </section>
+
+    <!-- Partner Ads Section (Top Duplicate) -->
+    <!-- Partner Ads Section -->
+    <section id="partner-ads-top" class="partner-ads">
+        <div class="container">
+            <div class="partner-ads-header" data-aos="fade-up">
+                <h2 class="section-title en text-center">Past and current client partners featured below.</h2>
+                <h2 class="section-title es text-center" style="display: none;">Clientes pasados y actuales destacados a continuacion.</h2>
+                <p class="partner-ads-subtitle en">Rotating highlights from recent local campaigns.</p>
+                <p class="partner-ads-subtitle es" style="display: none;">Anuncios destacados de campanas locales recientes.</p>
+            </div>
+        </div>
+        <div class="partner-ads-marquee" role="region" aria-label="Client partner ads">
+            <div class="partner-ads-track">
+                <div class="partner-ads-group">
+                    <div class="partner-ads-card">
+                        <a class="partner-ads-link" href="https://www.lapizzamaringlewood.com" target="_blank" rel="noopener noreferrer" aria-label="Visit La Pizza Mar website">
+                            <img src="Pizza ad.png" alt="Pizza ad" loading="lazy" decoding="async">
+                        </a>
+                    </div>
+                    <div class="partner-ads-card">
+                        <a class="partner-ads-link" href="https://www.google.com/maps/place/Sirius+Beauty+Salon+%26+Styles/@33.9368256,-118.3613456,17z/data=!4m14!1m7!3m6!1s0x80c2b6ecdac7dcdb:0xc0c290f55202d5e7!2sSirius+Beauty+Salon+%26+Styles!8m2!3d33.9368255!4d-118.3614847!16s%2Fg%2F1td3lvy3!3m5!1s0x80c2b6ecdac7dcdb:0xc0c290f55202d5e7!8m2!3d33.9368255!4d-118.3614847!16s%2Fg%2F1td3lvy3?authuser=0&entry=ttu&g_ep=EgoyMDI2MDEyOC4wIKXMDSoKLDEwMDc5MjA3M0gBUAM%3D" target="_blank" rel="noopener noreferrer" aria-label="Visit Sirius Beauty Salon & Styles on Google Maps">
+                            <img src="Salon Ad.png" alt="Salon ad" loading="lazy" decoding="async">
+                        </a>
+                    </div>
+                    <div class="partner-ads-card">
+                        <a class="partner-ads-link" href="https://tezanainsurance.com/en/" target="_blank" rel="noopener noreferrer" aria-label="Visit Tezana Insurance website">
+                            <img src="Insurance ad.png" alt="Insurance ad" loading="lazy" decoding="async">
+                        </a>
+                    </div>
+                    <div class="partner-ads-card">
+                        <a class="partner-ads-link" href="https://www.google.com/maps/place/Panamericana+Bakery+%23+3/@33.9347716,-118.3530201,16z/data=!4m10!1m2!2m1!1sbakery!3m6!1s0x80c2b68c6ee8b503:0x86898a843938265e!8m2!3d33.9347716!4d-118.3530201!15sCgZiYWtlcnlaCCIGYmFrZXJ5kgEGYmFrZXJ5mgEkQ2hkRFNVaE5NRzluUzBWSlEwRm5TVVJvYkhWTFZ5MUJSUkFC4AEA-gEECAAQEA!16s%2Fg%2F11cs2hf4np?authuser=0&entry=ttu&g_ep=EgoyMDI2MDEyOC4wIKXMDSoKLDEwMDc5MjA3M0gBUAM%3D" target="_blank" rel="noopener noreferrer" aria-label="Visit Panamericana Bakery #3 on Google Maps">
+                            <img src="Bakery ad.png" alt="Bakery ad" loading="lazy" decoding="async">
+                        </a>
+                    </div>
+                    <div class="partner-ads-card">
+                        <a class="partner-ads-link" href="https://www.google.com/maps/place/Princess+Jewelry/@33.9383089,-118.354406,20.25z/data=!4m6!3m5!1s0x80c2b6f32ec6f09f:0x3043b2df04a4262b!8m2!3d33.9383266!4d-118.3545788!16s%2Fg%2F1hc3hfsfk?authuser=0&entry=ttu&g_ep=EgoyMDI2MDEyOC4wIKXMDSoKLDEwMDc5MjA3M0gBUAM%3D" target="_blank" rel="noopener noreferrer" aria-label="Visit Princess Jewelry on Google Maps">
+                            <img src="Jewelry AD.png" alt="Jewelry ad" loading="lazy" decoding="async">
+                        </a>
+                    </div>
+                    <div class="partner-ads-card">
+                        <a class="partner-ads-link" href="https://lennoxfurniturediscount.com" target="_blank" rel="noopener noreferrer" aria-label="Visit Lennox Furniture Discount website">
+                            <img src="Lennox Furniture.png" alt="Lennox Furniture ad" loading="lazy" decoding="async">
+                        </a>
+                    </div>
+                    <div class="partner-ads-card">
+                        <a class="partner-ads-link" href="https://www.google.com/maps/place/EL+NUEVO+AMANECER+(BIRRIA,+POSOLE,+Y+MENUDO)/@33.9392651,-118.3532258,3a,75y,90t/data=!3m8!1e2!3m6!1sAF1QipMYfQ4rVebzID876eTwV2DN-zjI3qkT5jd37uZ5!2e10!3e12!6shttps:%2F%2Flh3.googleusercontent.com%2Fp%2FAF1QipMYfQ4rVebzID876eTwV2DN-zjI3qkT5jd37uZ5%3Dw86-h114-k-no!7i1440!8i1920!4m7!3m6!1s0x80c2b792184c1bcb:0x442d9d63559de598!8m2!3d33.9393145!4d-118.3530545!10e5!16s%2Fg%2F11lp7jygl8?authuser=0&entry=ttu&g_ep=EgoyMDI2MDEyOC4wIKXMDSoKLDEwMDc5MjA3M0gBUAM%3D" target="_blank" rel="noopener noreferrer" aria-label="Visit El Nuevo Amanecer on Google Maps">
+                            <img src="El Nuevo Amanecer.png" alt="El Nuevo Amanecer ad" loading="lazy" decoding="async">
+                        </a>
+                    </div>
+                    <div class="partner-ads-card">
+                        <a class="partner-ads-link" href="https://www.google.com/maps/place/Helados+Y+Antojitos+La+Korita/@33.9391565,-118.3527416,20z/data=!4m6!3m5!1s0x80c2b70c33664391:0xe12a622da2186f04!8m2!3d33.939156!4d-118.3528961!16s%2Fg%2F11wjh4v5bl?authuser=0&entry=ttu&g_ep=EgoyMDI2MDEyOC4wIKXMDSoKLDEwMDc5MjA3M0gBUAM%3D" target="_blank" rel="noopener noreferrer" aria-label="Visit La Korita on Google Maps">
+                            <img src="New La Korita Logo.png" alt="La Korita ad" loading="lazy" decoding="async">
+                        </a>
+                    </div>
+                    <div class="partner-ads-card">
+                        <a class="partner-ads-link" href="https://lennoxfurniturediscount.com" target="_blank" rel="noopener noreferrer" aria-label="Visit Lennox Furniture Discount website">
+                            <img src="Lennox Furniture Logo.png" alt="Lennox Furniture logo" loading="lazy" decoding="async">
+                        </a>
+                    </div>
+                    <div class="partner-ads-card">
+                        <a class="partner-ads-link" href="https://tezanainsurance.com/locations/inglewood/" target="_blank" rel="noopener noreferrer" aria-label="Visit Tezana Insurance Inglewood location">
+                            <img src="Tezana Insurance.png" alt="Tezana Insurance logo" loading="lazy" decoding="async">
+                        </a>
+                    </div>
+                </div>
+                <div class="partner-ads-group" aria-hidden="true">
+                    <div class="partner-ads-card">
+                        <a class="partner-ads-link" href="https://www.lapizzamaringlewood.com" target="_blank" rel="noopener noreferrer" tabindex="-1">
+                            <img src="Pizza ad.png" alt="" loading="lazy" decoding="async">
+                        </a>
+                    </div>
+                    <div class="partner-ads-card">
+                        <a class="partner-ads-link" href="https://www.google.com/maps/place/Sirius+Beauty+Salon+%26+Styles/@33.9368256,-118.3613456,17z/data=!4m14!1m7!3m6!1s0x80c2b6ecdac7dcdb:0xc0c290f55202d5e7!2sSirius+Beauty+Salon+%26+Styles!8m2!3d33.9368255!4d-118.3614847!16s%2Fg%2F1td3lvy3!3m5!1s0x80c2b6ecdac7dcdb:0xc0c290f55202d5e7!8m2!3d33.9368255!4d-118.3614847!16s%2Fg%2F1td3lvy3?authuser=0&entry=ttu&g_ep=EgoyMDI2MDEyOC4wIKXMDSoKLDEwMDc5MjA3M0gBUAM%3D" target="_blank" rel="noopener noreferrer" tabindex="-1">
+                            <img src="Salon Ad.png" alt="" loading="lazy" decoding="async">
+                        </a>
+                    </div>
+                    <div class="partner-ads-card">
+                        <a class="partner-ads-link" href="https://tezanainsurance.com/en/" target="_blank" rel="noopener noreferrer" tabindex="-1">
+                            <img src="Insurance ad.png" alt="" loading="lazy" decoding="async">
+                        </a>
+                    </div>
+                    <div class="partner-ads-card">
+                        <a class="partner-ads-link" href="https://www.google.com/maps/place/Panamericana+Bakery+%23+3/@33.9347716,-118.3530201,16z/data=!4m10!1m2!2m1!1sbakery!3m6!1s0x80c2b68c6ee8b503:0x86898a843938265e!8m2!3d33.9347716!4d-118.3530201!15sCgZiYWtlcnlaCCIGYmFrZXJ5kgEGYmFrZXJ5mgEkQ2hkRFNVaE5NRzluUzBWSlEwRm5TVVJvYkhWTFZ5MUJSUkFC4AEA-gEECAAQEA!16s%2Fg%2F11cs2hf4np?authuser=0&entry=ttu&g_ep=EgoyMDI2MDEyOC4wIKXMDSoKLDEwMDc5MjA3M0gBUAM%3D" target="_blank" rel="noopener noreferrer" tabindex="-1">
+                            <img src="Bakery ad.png" alt="" loading="lazy" decoding="async">
+                        </a>
+                    </div>
+                    <div class="partner-ads-card">
+                        <a class="partner-ads-link" href="https://www.google.com/maps/place/Princess+Jewelry/@33.9383089,-118.354406,20.25z/data=!4m6!3m5!1s0x80c2b6f32ec6f09f:0x3043b2df04a4262b!8m2!3d33.9383266!4d-118.3545788!16s%2Fg%2F1hc3hfsfk?authuser=0&entry=ttu&g_ep=EgoyMDI2MDEyOC4wIKXMDSoKLDEwMDc5MjA3M0gBUAM%3D" target="_blank" rel="noopener noreferrer" tabindex="-1">
+                            <img src="Jewelry AD.png" alt="" loading="lazy" decoding="async">
+                        </a>
+                    </div>
+                    <div class="partner-ads-card">
+                        <a class="partner-ads-link" href="https://lennoxfurniturediscount.com" target="_blank" rel="noopener noreferrer" tabindex="-1">
+                            <img src="Lennox Furniture.png" alt="" loading="lazy" decoding="async">
+                        </a>
+                    </div>
+                    <div class="partner-ads-card">
+                        <a class="partner-ads-link" href="https://www.google.com/maps/place/EL+NUEVO+AMANECER+(BIRRIA,+POSOLE,+Y+MENUDO)/@33.9392651,-118.3532258,3a,75y,90t/data=!3m8!1e2!3m6!1sAF1QipMYfQ4rVebzID876eTwV2DN-zjI3qkT5jd37uZ5!2e10!3e12!6shttps:%2F%2Flh3.googleusercontent.com%2Fp%2FAF1QipMYfQ4rVebzID876eTwV2DN-zjI3qkT5jd37uZ5%3Dw86-h114-k-no!7i1440!8i1920!4m7!3m6!1s0x80c2b792184c1bcb:0x442d9d63559de598!8m2!3d33.9393145!4d-118.3530545!10e5!16s%2Fg%2F11lp7jygl8?authuser=0&entry=ttu&g_ep=EgoyMDI2MDEyOC4wIKXMDSoKLDEwMDc5MjA3M0gBUAM%3D" target="_blank" rel="noopener noreferrer" tabindex="-1">
+                            <img src="El Nuevo Amanecer.png" alt="" loading="lazy" decoding="async">
+                        </a>
+                    </div>
+                    <div class="partner-ads-card">
+                        <a class="partner-ads-link" href="https://www.google.com/maps/place/Helados+Y+Antojitos+La+Korita/@33.9391565,-118.3527416,20z/data=!4m6!3m5!1s0x80c2b70c33664391:0xe12a622da2186f04!8m2!3d33.939156!4d-118.3528961!16s%2Fg%2F11wjh4v5bl?authuser=0&entry=ttu&g_ep=EgoyMDI2MDEyOC4wIKXMDSoKLDEwMDc5MjA3M0gBUAM%3D" target="_blank" rel="noopener noreferrer" tabindex="-1">
+                            <img src="New La Korita Logo.png" alt="" loading="lazy" decoding="async">
+                        </a>
+                    </div>
+                    <div class="partner-ads-card">
+                        <a class="partner-ads-link" href="https://lennoxfurniturediscount.com" target="_blank" rel="noopener noreferrer" tabindex="-1">
+                            <img src="Lennox Furniture Logo.png" alt="" loading="lazy" decoding="async">
+                        </a>
+                    </div>
+                    <div class="partner-ads-card">
+                        <a class="partner-ads-link" href="https://tezanainsurance.com/locations/inglewood/" target="_blank" rel="noopener noreferrer" tabindex="-1">
+                            <img src="Tezana Insurance.png" alt="" loading="lazy" decoding="async">
+                        </a>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </section>
+
     <!-- Parallax Transition Container -->
     <div class="parallax-container" id="parallax-transition">
         <!-- Background Layers -->
@@ -4340,10 +4462,10 @@ Es comprobado, asequible, exclusivo, y diseñado para máxima exposición. Asegu
                             <div class="starter-location es" style="display: none;">Lennox o Hawthorne</div>
                         </div>
                         <ul class="starter-features">
-                            <li class="en"><span class="feature-label">Regular Square:</span> $158</li>
-                            <li class="es" style="display: none;"><span class="feature-label">Cuadrado Regular:</span> $158</li>
-                            <li class="en"><span class="feature-label">Double Size:</span> $300</li>
-                            <li class="es" style="display: none;"><span class="feature-label">Tamaño Doble:</span> $300</li>
+                            <li class="en"><span class="feature-label">Regular Square:</span> Promo $158 (Regular $197)</li>
+                            <li class="es" style="display: none;"><span class="feature-label">Cuadrado Regular:</span> Promo $158 (Regular $197)</li>
+                            <li class="en"><span class="feature-label">Double Size:</span> Promo $305 (Regular $395)</li>
+                            <li class="es" style="display: none;"><span class="feature-label">Tamaño Doble:</span> Promo $305 (Regular $395)</li>
                             <li class="en">Design included</li>
                             <li class="es" style="display: none;">Diseño incluido</li>
                             <li class="en">Print & postage included</li>
@@ -4370,10 +4492,10 @@ Es comprobado, asequible, exclusivo, y diseñado para máxima exposición. Asegu
                             <div class="starter-location es" style="display: none;">Lennox + Hawthorne</div>
                         </div>
                         <ul class="starter-features">
-                            <li class="en"><span class="feature-label">Regular Square:</span> $350</li>
-                            <li class="es" style="display: none;"><span class="feature-label">Cuadrado Regular:</span> $350</li>
-                            <li class="en"><span class="feature-label">Double Size:</span> $692</li>
-                            <li class="es" style="display: none;"><span class="feature-label">Tamaño Doble:</span> $692</li>
+                            <li class="en"><span class="feature-label">Regular Square:</span> Promo $350 (Regular $395)</li>
+                            <li class="es" style="display: none;"><span class="feature-label">Cuadrado Regular:</span> Promo $350 (Regular $395)</li>
+                            <li class="en"><span class="feature-label">Double Size:</span> Promo $692 (Regular $788)</li>
+                            <li class="es" style="display: none;"><span class="feature-label">Tamaño Doble:</span> Promo $692 (Regular $788)</li>
                             <li class="en">Design included</li>
                             <li class="es" style="display: none;">Diseño incluido</li>
                             <li class="en">Print & postage included</li>
@@ -6135,8 +6257,8 @@ Es comprobado, asequible, exclusivo, y diseñado para máxima exposición. Asegu
             <!-- Footer Bottom -->
             <div class="footer-bottom" style="border-top: 1px solid rgba(255,255,255,0.1); padding: 30px 0; display: flex; justify-content: space-between; align-items: center; flex-wrap: wrap; gap: 20px;">
                 <div style="display: flex; flex-direction: column; gap: 5px;">
-                    <p class="en" style="margin: 0; color: #90a4ae; font-size: 0.9rem;">&copy; 2025 Lennox Local Ads Flyer. All Rights Reserved.</p>
-                    <p class="es" style="display: none; margin: 0; color: #90a4ae; font-size: 0.9rem;">&copy; 2025 Lennox Local Ads Flyer. Todos los Derechos Reservados.</p>
+                    <p class="en" style="margin: 0; color: #90a4ae; font-size: 0.9rem;">&copy; 2026 Lennox Local Ads Flyer. All Rights Reserved.</p>
+                    <p class="es" style="display: none; margin: 0; color: #90a4ae; font-size: 0.9rem;">&copy; 2026 Lennox Local Ads Flyer. Todos los Derechos Reservados.</p>
                     
 
                     


### PR DESCRIPTION
### Motivation
- Refresh promotional pricing and clarify copy across the landing page to reflect the current offer and launch-member messaging. 
- Replace and update hero imagery and alt text for the updated campaign creative. 
- Surface client partner logos in a marquee to showcase past and current partners and improve accessibility and labeling.

### Description
- Adjusted hero copy and styles including changing the highlight color span to `#d4af37`, rewording the hero paragraph, and replacing the main hero image `src` and `alt`. 
- Updated pricing and promotional messaging site-wide including changing the starter listing in `#latest-updates` from `$150` to `Promo $158`, and expanded the starter grid to show promo vs regular prices (e.g. `Promo $158 (Regular $197)` and updated double-size pricing). 
- Added a new `#partner-ads-top` marquee section containing partner cards with `loading="lazy"`, `decoding="async"`, descriptive `alt` text and `aria-label`s, and a duplicate hidden group for continuous scrolling. 
- Minor content and footer updates including updating copyright year to `2026` and small CTA text adjustments.

### Testing
- Ran HTML linting via `npm run lint` and no lint errors were reported. 
- Executed an accessibility scan with `npm run a11y` (axe) to verify `alt` and `aria` attributes, which passed the configured checks. 
- Performed a local build with `npm run build` and a browser smoke test to confirm the page renders and the marquee assets load, and the build succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c1fe2a6294832da658033a4ac345cd)